### PR TITLE
provider/opc: Change `parent_pool` to an Optional attribute

### DIFF
--- a/opc/resource_ip_reservation.go
+++ b/opc/resource_ip_reservation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-oracle-terraform/compute"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceOPCIPReservation() *schema.Resource {
@@ -31,8 +32,11 @@ func resourceOPCIPReservation() *schema.Resource {
 			"parent_pool": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "/oracle/public/ippool",
+				Default:  string(compute.PublicReservationPool),
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.PublicReservationPool),
+				}, true),
 			},
 			"tags": tagsForceNewSchema(),
 			"ip": {

--- a/opc/resource_ip_reservation.go
+++ b/opc/resource_ip_reservation.go
@@ -30,7 +30,8 @@ func resourceOPCIPReservation() *schema.Resource {
 			},
 			"parent_pool": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "/oracle/public/ippool",
 				ForceNew: true,
 			},
 			"tags": tagsForceNewSchema(),

--- a/opc/resource_ip_reservation_test.go
+++ b/opc/resource_ip_reservation_test.go
@@ -28,6 +28,26 @@ func TestAccOPCIPReservation_Basic(t *testing.T) {
 	})
 }
 
+func TestAccOPCIPreservation_OptionalParentPool(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIPReservationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCIPReservationOptionalPool(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPReservationExists,
+					resource.TestCheckResourceAttr(
+						"opc_compute_ip_reservation.test", "parent_pool", "/oracle/public/ippool"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIPReservationExists(s *terraform.State) error {
 	client := testAccProvider.Meta().(*compute.Client).IPReservations()
 
@@ -73,3 +93,11 @@ resource "opc_compute_ip_reservation" "test" {
   permanent   = true
 }
 `
+
+func testAccOPCIPReservationOptionalPool(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_ip_reservation" "test" {
+  name        = "acc-test-ip-reservation-%d"
+  permanent   = true
+}`, rInt)
+}


### PR DESCRIPTION
Changes the `parent_pool` attribute to an Optional attribute in the `opc_compute_ip_reservation` resource.
There can only be one possible value for this attribute, so it doesn't make sense to force users to supply it.
It's marked as optional with a default though, in the off-chance that it can be changed to a different value.

```
$ make testacc TEST=./builtin/providers/opc TESTARGS="-run=TestAccOPCIPreservation_OptionalParentPool"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/16 10:33:56 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc -v -run=TestAccOPCIPreservation_OptionalParentPool -timeout 120m
=== RUN   TestAccOPCIPreservation_OptionalParentPool
--- PASS: TestAccOPCIPreservation_OptionalParentPool (16.33s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/opc    16.334s
```
Associated Docs PR: https://github.com/hashicorp/terraform/pull/14544